### PR TITLE
Updated readme examples to es6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,25 @@ Nodecast-js is a simple module for streaming media to Chromecast/UPnP/DLNA.
 ## Usage
 
 ```javascript
-var Browser = require('nodecast-js');
+const NodeCast = require('nodecast-js');
 
-var url = 'http://commondatastorage.googleapis.com/gtv-videos-bucket/big_buck_bunny_1080p.mp4';
-var timestamp = 60; // in seconds
+const url = 'http://commondatastorage.googleapis.com/gtv-videos-bucket/big_buck_bunny_1080p.mp4';
+const timestamp = 60; // in seconds
+const nodeCast = new NodeCast();
 
-var browser = new Browser();
-browser.onDevice(function (device) {
-    device.onError(function (err) {
+nodeCast.onDevice(device => {
+    device.onError(err => {
         console.log(err);
     });
     
-    console.log(browser.getList()); // list of currently discovered devices
+    console.log(nodeCast.getList()); // list of currently discovered devices
 
     device.play(url, timestamp);
 });
-browser.start();
 
-setTimeout(function () {
-    browser.destroy(); // destroy your browser
+nodeCast.start();
+
+setTimeout(() => {
+    nodeCast.destroy(); // destroy nodecast
 }, 20000);
 ```

--- a/examples/cast.js
+++ b/examples/cast.js
@@ -1,20 +1,21 @@
-var Browser = require('nodecast-js');
+const NodeCast = require('nodecast-js');
 
-var url = 'http://commondatastorage.googleapis.com/gtv-videos-bucket/big_buck_bunny_1080p.mp4';
-var timestamp = 60; // in seconds
+const url = 'http://commondatastorage.googleapis.com/gtv-videos-bucket/big_buck_bunny_1080p.mp4';
+const timestamp = 60; // in seconds
+const nodeCast = new NodeCast();
 
-var browser = new Browser();
-browser.onDevice(function (device) {
-    device.onError(function (err) {
+nodeCast.onDevice(device => {
+    device.onError(err => {
         console.log(err);
     });
-
-    console.log(browser.getList()); // list of currently discovered devices
+    
+    console.log(nodeCast.getList()); // list of currently discovered devices
 
     device.play(url, timestamp);
 });
-browser.start();
 
-setTimeout(function () {
-    browser.destroy(); // destroy your browser
+nodeCast.start();
+
+setTimeout(() => {
+    nodeCast.destroy(); // destroy nodecast
 }, 20000);


### PR DESCRIPTION
`Browser` was changed to `NodeCast` to avoid confusion between the actual 'Browser environment' and the nodecast browser
